### PR TITLE
fix: shallow comparison should compare items not arrays

### DIFF
--- a/src/related.ts
+++ b/src/related.ts
@@ -32,7 +32,7 @@ const shallowIsEqual = (a: any[], b: any[]): boolean => {
   if (a.length !== b.length) { return false; }
 
   for (let i = 0; i < a.length; i++) {
-    if (a !== b) {
+    if (a[i] !== b[i]) {
       return false
     }
   }


### PR DESCRIPTION
I have a feeling that there was some mistake in the `shallowIsEqual` function. It seems to compare `a` and `b` n times rather than comparing every single item in `a` and `b`...

This PR suggests a fix